### PR TITLE
refactor: extract duplicated pad() and formatDelta() to shared utility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agents-reverse-engineer",
-  "version": "1.2.10",
+  "version": "1.2.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agents-reverse-engineer",
-      "version": "1.2.10",
+      "version": "1.2.12",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.3",

--- a/src/implement/views/comparison.ts
+++ b/src/implement/views/comparison.ts
@@ -9,29 +9,8 @@
 
 import pc from 'picocolors';
 import { formatCost, formatDuration, formatTokens } from '../../dashboard/cost-calculator.js';
+import { formatDelta, pad } from '../../views/format-utils.js';
 import type { ImplementationComparison } from '../types.js';
-
-/**
- * Format a percentage delta string with color.
- *
- * Positive deltas (improvements) are green, negative are red.
- */
-function formatDelta(withVal: number, withoutVal: number): string {
-  if (withoutVal === 0) return withVal > 0 ? pc.green('N/A \u2192 ' + String(withVal)) : '\u2014';
-  const pct = ((withVal - withoutVal) / withoutVal * 100);
-  const sign = pct >= 0 ? '+' : '';
-  const formatted = `${sign}${Math.round(pct)}%`;
-  return pct >= 0 ? pc.green(formatted) : pc.red(formatted);
-}
-
-/**
- * Pad a string to a fixed width (right-padded).
- */
-function pad(str: string, width: number): string {
-  const stripped = str.replace(/\x1B\[\d+m/g, '');
-  const padding = Math.max(0, width - stripped.length);
-  return str + ' '.repeat(padding);
-}
 
 /**
  * Render the full implementation comparison report to the terminal.

--- a/src/implement/views/list.ts
+++ b/src/implement/views/list.ts
@@ -8,16 +8,8 @@
 
 import pc from 'picocolors';
 import { formatCost } from '../../dashboard/cost-calculator.js';
+import { pad } from '../../views/format-utils.js';
 import type { ImplementationComparison } from '../types.js';
-
-/**
- * Pad a string to a fixed width.
- */
-function pad(str: string, width: number): string {
-  const stripped = str.replace(/\x1B\[\d+m/g, '');
-  const padding = Math.max(0, width - stripped.length);
-  return str + ' '.repeat(padding);
-}
 
 /**
  * Render the list of saved implementation comparisons.

--- a/src/plan/views/comparison.ts
+++ b/src/plan/views/comparison.ts
@@ -9,31 +9,8 @@
 
 import pc from 'picocolors';
 import { formatCost, formatDuration, formatTokens } from '../../dashboard/cost-calculator.js';
+import { formatDelta, pad } from '../../views/format-utils.js';
 import type { PlanComparison } from '../types.js';
-
-/**
- * Format a percentage delta string with color.
- *
- * Positive deltas (improvements) are green, negative are red.
- * For metrics where higher is better (tokens, sections, file refs, etc.)
- */
-function formatDelta(withVal: number, withoutVal: number): string {
-  if (withoutVal === 0) return withVal > 0 ? pc.green('N/A → ' + String(withVal)) : '—';
-  const pct = ((withVal - withoutVal) / withoutVal * 100);
-  const sign = pct >= 0 ? '+' : '';
-  const formatted = `${sign}${Math.round(pct)}%`;
-  return pct >= 0 ? pc.green(formatted) : pc.red(formatted);
-}
-
-/**
- * Pad a string to a fixed width (right-padded).
- */
-function pad(str: string, width: number): string {
-  // Strip ANSI codes for length calculation
-  const stripped = str.replace(/\x1B\[\d+m/g, '');
-  const padding = Math.max(0, width - stripped.length);
-  return str + ' '.repeat(padding);
-}
 
 /**
  * Render the full comparison report to the terminal.

--- a/src/plan/views/list.ts
+++ b/src/plan/views/list.ts
@@ -8,16 +8,8 @@
 
 import pc from 'picocolors';
 import { formatCost, formatDuration } from '../../dashboard/cost-calculator.js';
+import { pad } from '../../views/format-utils.js';
 import type { PlanComparison } from '../types.js';
-
-/**
- * Pad a string to a fixed width.
- */
-function pad(str: string, width: number): string {
-  const stripped = str.replace(/\x1B\[\d+m/g, '');
-  const padding = Math.max(0, width - stripped.length);
-  return str + ' '.repeat(padding);
-}
 
 /**
  * Render the list of saved plan comparisons.

--- a/src/views/format-utils.ts
+++ b/src/views/format-utils.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared formatting utilities for terminal views.
+ *
+ * Provides ANSI-aware string padding and delta formatting for
+ * plan and implementation comparison tables.
+ *
+ * @module
+ */
+
+import pc from 'picocolors';
+
+/**
+ * Pad a string to a fixed width (right-padded).
+ *
+ * Strips ANSI escape codes for accurate length calculation,
+ * then pads with spaces to the target width.
+ *
+ * @param str - String to pad (may contain ANSI codes)
+ * @param width - Target width in visible characters
+ * @returns Padded string
+ */
+export function pad(str: string, width: number): string {
+  // Strip ANSI codes for length calculation
+  const stripped = str.replace(/\x1B\[\d+m/g, '');
+  const padding = Math.max(0, width - stripped.length);
+  return str + ' '.repeat(padding);
+}
+
+/**
+ * Format a percentage delta string with color.
+ *
+ * Positive deltas (improvements) are green, negative are red.
+ * For metrics where higher is better (tokens, sections, file refs, etc.)
+ *
+ * @param withVal - Value from "with docs" run
+ * @param withoutVal - Value from "without docs" baseline
+ * @returns Colored percentage string or N/A indicator
+ */
+export function formatDelta(withVal: number, withoutVal: number): string {
+  if (withoutVal === 0) return withVal > 0 ? pc.green('N/A → ' + String(withVal)) : '—';
+  const pct = ((withVal - withoutVal) / withoutVal * 100);
+  const sign = pct >= 0 ? '+' : '';
+  const formatted = `${sign}${Math.round(pct)}%`;
+  return pct >= 0 ? pc.green(formatted) : pc.red(formatted);
+}


### PR DESCRIPTION
Create src/views/format-utils.ts exporting pad() and formatDelta() functions that were previously duplicated across four view files:
- src/plan/views/comparison.ts
- src/plan/views/list.ts
- src/implement/views/comparison.ts
- src/implement/views/list.ts

Both utilities handle ANSI escape codes correctly for terminal formatting:
- pad() strips ANSI codes for accurate width calculations
- formatDelta() formats percentage changes with green/red coloring

This refactoring reduces code duplication by ~80 lines and ensures consistent formatting behavior across all comparison views.